### PR TITLE
Added Kafka (zookeeper, bitnami) to docker-compose file

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,5 +1,21 @@
 version: '2.1'
 services:
+  zookeeper:
+    image: bitnami/zookeeper:3
+    ports:
+      - "2181:2181"
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+  kafka:
+    image: bitnami/kafka:2
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: "1"
+      KAFKA_LISTENERS: "PLAINTEXT://:9092"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://172.17.0.1:9092"
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      ALLOW_PLAINTEXT_LISTENER: "yes"
   mongodb:
     image: mongo:4.1.1-xenial
     ports:

--- a/server/docker-configurations/cards-publication.yml
+++ b/server/docker-configurations/cards-publication.yml
@@ -16,6 +16,7 @@ spring:
 #  kafka:
 #    consumer:
 #      group-id: opfab-command
+#    bootstrap-servers: 172.17.0.1:9092
 
 opfab:
   kafka:
@@ -34,7 +35,8 @@ users:
     listOfServers: users:8080
 
 externalRecipients-url: "{\
-          externalRecipient: \"http://ext-app:8090/test\" \
+          externalRecipient: \"http://ext-app:8090/test\", \
+          externalKafkaRecipient: \"kafka:\" \
           }"
 
 # WARNING : If you set this parameter to false , all users have the rights to respond to all cards


### PR DESCRIPTION
Suggestion to include zookeeper and bitnami images. This way Kafka can be enabled without the user having to worry about setting up the Kafka environment.
Note the default docker gateway address is hardcoded (172.17.0.1).